### PR TITLE
Add /shuttles endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import express, { type Request, type Response } from "express";
 import announcementsRoute from "./routes/announcements.ts"
+import shuttleRoute from "./routes/shuttle.ts"
 const app = express()
 
 app.get("/", (request: Request, response: Response) => {
@@ -9,6 +10,7 @@ app.get("/", (request: Request, response: Response) => {
 
 
 app.use("/announcements", announcementsRoute)
+app.use("/shuttle", shuttleRoute)
 
 app.listen(3000, () => {
     console.log("API running on :3000!")

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ app.get("/", (request: Request, response: Response) => {
 
 
 app.use("/announcements", announcementsRoute)
-app.use("/shuttle", shuttleRoute)
+app.use("/shuttles", shuttleRoute)
 
 app.listen(3000, () => {
     console.log("API running on :3000!")

--- a/src/models/shuttle.d.ts
+++ b/src/models/shuttle.d.ts
@@ -1,0 +1,33 @@
+/**
+ * @description
+ * The Shuttle object that our API is returning.
+ * This one is different from the Champlain one because it cleans up
+ * some unused fields and changes some existing ones.
+ * Ours does not include the `Unit_Name` or `Unit_Operator`
+ * We also change `Knots` to MPH.
+ */
+export type Shuttle = {
+    DateTimeISO: Date,
+    UnitID: number,
+    Lat: string
+    Lon: string
+    MPH: number
+    Direction: number
+}
+
+
+/**
+ * @description This is the Champlain shuttle object.
+ * @see {@link Shuttle} for the Shuttle that we are returning.
+ */
+export type _ChamplainShuttle = {
+    Date_Time: string
+    Date_Time_ISO: string
+    UnitID: string
+    Unit_Name: string | Object
+    Unit_Operator: string
+    Lat: string
+    Lon: string
+    Knots: string
+    Direction: string
+}

--- a/src/routes/shuttle.ts
+++ b/src/routes/shuttle.ts
@@ -1,51 +1,103 @@
+/*
+ * shuttle.ts
+ * This defines the routes for the shuttle endpoint.
+ * 
+ * Users can do the following:
+ * 
+ * Request all shuttles
+ * GET /shuttles
+ * 
+ * Request all shuttles and filter by a given cutoffHour. 
+ * This will only return shuttles that have been updated
+ * within X number of hours. This defaults to 2.
+ * GET /shuttles?cutoffHours=X
+ * Returns a 400 if the cutoffHours are invalid.
+ * 
+ * Request a specific shuttle given a ID
+ * GET /shuttles/:id
+ * Returns a 404 if the ID is invalid.
+ * 
+ * 
+ */
+
 import express, { type Response, type Request } from "express"
 import type { _ChamplainShuttle, Shuttle } from "../types/shuttle.d.ts"
 const router = express.Router()
 
-router.get("/", async (req: Request, res: Response) => {
-    // Set our response's content type.
-    res.setHeader("Content-Type", "application/json")
+router
+    .get("/", async (req: Request, res: Response) => {
+        // Set our response's content type.
+        res.setHeader("Content-Type", "application/json")
 
-    const champlainShuttleData = await fetch("https://shuttle.champlain.edu/shuttledata", {
-        headers: {
-            "Content-Type": "application/json"
+        const champlainShuttleData = await fetch("https://shuttle.champlain.edu/shuttledata", {
+            headers: {
+                "Content-Type": "application/json"
+            }
+        })
+        const data = await champlainShuttleData.json()
+
+        let shuttles: Shuttle[] = [];
+
+        // Return 2 if the functions fails (such as returns NaN) or if the user provides no number
+        const cutoffHours = Number(req.query["cutoffHours"] ?? 2) || 2
+        // check to make sure the cutoff hours is valid
+        // > 1 and <= 1 week
+        if (cutoffHours < 1 || cutoffHours >= 1 * 24 * 7) {
+            res.status(400).json({ "error": "cutoffHours is not valid." })
         }
+        const twoHoursAgo = new Date(Date.now()).getTime() - (1000 * 1 * 60 * 60 * cutoffHours)
+
+        for (var oldShuttle of data as _ChamplainShuttle[]) {
+            // Check if the shuttle is within our cutoff time.
+            // If it is, add it to the array so it can be returned
+            const isWithinCutoffTime = new Date(oldShuttle.Date_Time) > new Date(twoHoursAgo)
+
+            if (isWithinCutoffTime) {
+                // Format it to how we should return our shuttles.
+                let newShuttle: Shuttle = makeNewShuttle(oldShuttle)
+
+                shuttles.push(newShuttle)
+            }
+
+
+        }
+        res.send(shuttles)
     })
-    const data = await champlainShuttleData.json()
+    .get("/:id", async (req: Request, res: Response) => {
+        // Set our response's content type.
+        res.setHeader("Content-Type", "application/json")
 
-    let shuttles: Shuttle[] = [];
-
-    // Return 2 if the functions fails (such as returns NaN) or if the user provides no number
-    const cutoffHours = Number(req.query["cutoffHours"] ?? 2) || 2
-    // check to make sure the cutoff hours is valid
-    // > 1 and <= 1 week (168 hours)
-    if (cutoffHours < 1 || cutoffHours >= 1 * 24 * 7) {
-        res.status(400).json({ "error": "cutoffHours is not valid." })
-    }
-    const twoHoursAgo = new Date(Date.now()).getTime() - (1000 * 1 * 60 * 60 * cutoffHours)
-
-    for (var oldShuttle of data as _ChamplainShuttle[]) {
-        // Check if the shuttle is within our cutoff time.
-        // If it is, add it to the array so it can be returned
-        const isWithinCutoffTime = new Date(oldShuttle.Date_Time) > new Date(twoHoursAgo)
-
-        if (isWithinCutoffTime) {
-            // Format it to how we should return our shuttles.
-            let newShuttle: Shuttle = Object()
-            newShuttle.DateTime = new Date(oldShuttle.Date_Time_ISO)
-            newShuttle.Direction = oldShuttle.Direction
-            newShuttle.Lat = oldShuttle.Lat
-            newShuttle.Lon = oldShuttle.Lon
-            newShuttle.UnitID = Number(oldShuttle.UnitID)
-            newShuttle.MPH = String((Number(oldShuttle.Knots) * 1.15).toFixed(2))
-
-            shuttles.push(newShuttle)
+        const champlainShuttleData = await fetch("https://shuttle.champlain.edu/shuttledata", {
+            headers: {
+                "Content-Type": "application/json"
+            }
+        })
+        const data = await champlainShuttleData.json()
+        for (var shuttle of data as _ChamplainShuttle[]) {
+            if (shuttle.UnitID == req.params["id"]) {
+                res.json(makeNewShuttle(shuttle))
+                return
+            }
         }
 
+        res.status(404).json({ "error": "No shuttle found." })
+    })
 
-    }
-    res.send(shuttles)
-})
-
+/**
+ * @description Creates and returns a new shuttle object from an
+ * old Champlain one.
+ * @param oldShuttle the old {@link _ChamplainShuttle}
+ * @returns a new {@link Shuttle}
+ */
+function makeNewShuttle(oldShuttle: _ChamplainShuttle): Shuttle {
+    let newShuttle: Shuttle = Object()
+    newShuttle.updated = new Date(oldShuttle.Date_Time_ISO)
+    newShuttle.direction = oldShuttle.Direction
+    newShuttle.lat = oldShuttle.Lat
+    newShuttle.lon = oldShuttle.Lon
+    newShuttle.id = Number(oldShuttle.UnitID)
+    newShuttle.mph = String((Number(oldShuttle.Knots) * 1.15).toFixed(2))
+    return newShuttle
+}
 
 export default router

--- a/src/routes/shuttle.ts
+++ b/src/routes/shuttle.ts
@@ -1,0 +1,38 @@
+import express, { type Response, type Request } from "express"
+import type { _ChamplainShuttle, Shuttle } from "../models/shuttle.js"
+const router = express.Router()
+
+router.get("/", async (req: Request, res: Response) => {
+    res.setHeader("Content-Type", "application/json")
+    const champlainShuttleData = await fetch("https://shuttle.champlain.edu/shuttledata")
+    let data = await champlainShuttleData.json()
+
+    let shuttles: Shuttle[] = [];
+
+    for (var oldShuttle of data as _ChamplainShuttle[]) {
+        const twoHoursAgo = new Date(Date.now()).getTime() - (1000 * 1 * 60 * 60 * 2)
+
+        // Check if the shuttle is within our cutoff time.
+        // If it is, add it to the array so it can be returned
+        if (new Date(oldShuttle.Date_Time) > new Date(twoHoursAgo)) {
+
+            // Format it to how we should return our shuttles.
+            let newShuttle: Shuttle = Object()
+            newShuttle.DateTimeISO = new Date(oldShuttle.Date_Time_ISO)
+            newShuttle.Direction = Number(oldShuttle.Direction)
+            newShuttle.Lat = oldShuttle.Lat
+            newShuttle.Lon = oldShuttle.Lon
+            newShuttle.UnitID = Number(oldShuttle.UnitID)
+            newShuttle.MPH = Number(oldShuttle.Knots) * 1.15
+
+            shuttles.push(newShuttle)
+        }
+
+
+    }
+
+    res.send(shuttles)
+})
+
+
+export default router

--- a/src/routes/shuttle.ts
+++ b/src/routes/shuttle.ts
@@ -41,6 +41,7 @@ router
         // > 1 and <= 1 week
         if (updatedWithinParam < 0 || updatedWithinParam > 1 * 24 * 7) {
             res.status(400).json({ "error": "updatedWithin is not valid. Must be between 1 and 168 (1 week) inclusive." })
+            return
         }
         const updatedWithinValue = new Date(Date.now()).getTime() - (1000 * 1 * 60 * 60 * updatedWithinParam)
 

--- a/src/routes/shuttle.ts
+++ b/src/routes/shuttle.ts
@@ -1,36 +1,49 @@
 import express, { type Response, type Request } from "express"
-import type { _ChamplainShuttle, Shuttle } from "../models/shuttle.js"
+import type { _ChamplainShuttle, Shuttle } from "../types/shuttle.d.ts"
 const router = express.Router()
 
 router.get("/", async (req: Request, res: Response) => {
+    // Set our response's content type.
     res.setHeader("Content-Type", "application/json")
-    const champlainShuttleData = await fetch("https://shuttle.champlain.edu/shuttledata")
-    let data = await champlainShuttleData.json()
+
+    const champlainShuttleData = await fetch("https://shuttle.champlain.edu/shuttledata", {
+        headers: {
+            "Content-Type": "application/json"
+        }
+    })
+    const data = await champlainShuttleData.json()
 
     let shuttles: Shuttle[] = [];
 
-    for (var oldShuttle of data as _ChamplainShuttle[]) {
-        const twoHoursAgo = new Date(Date.now()).getTime() - (1000 * 1 * 60 * 60 * 2)
+    // Return 2 if the functions fails (such as returns NaN) or if the user provides no number
+    const cutoffHours = Number(req.query["cutoffHours"] ?? 2) || 2
+    // check to make sure the cutoff hours is valid
+    // > 1 and <= 1 week (168 hours)
+    if (cutoffHours < 1 || cutoffHours >= 1 * 24 * 7) {
+        res.status(400).json({ "error": "cutoffHours is not valid." })
+    }
+    const twoHoursAgo = new Date(Date.now()).getTime() - (1000 * 1 * 60 * 60 * cutoffHours)
 
+    for (var oldShuttle of data as _ChamplainShuttle[]) {
         // Check if the shuttle is within our cutoff time.
         // If it is, add it to the array so it can be returned
-        if (new Date(oldShuttle.Date_Time) > new Date(twoHoursAgo)) {
+        const isWithinCutoffTime = new Date(oldShuttle.Date_Time) > new Date(twoHoursAgo)
 
+        if (isWithinCutoffTime) {
             // Format it to how we should return our shuttles.
             let newShuttle: Shuttle = Object()
-            newShuttle.DateTimeISO = new Date(oldShuttle.Date_Time_ISO)
-            newShuttle.Direction = Number(oldShuttle.Direction)
+            newShuttle.DateTime = new Date(oldShuttle.Date_Time_ISO)
+            newShuttle.Direction = oldShuttle.Direction
             newShuttle.Lat = oldShuttle.Lat
             newShuttle.Lon = oldShuttle.Lon
             newShuttle.UnitID = Number(oldShuttle.UnitID)
-            newShuttle.MPH = Number(oldShuttle.Knots) * 1.15
+            newShuttle.MPH = String((Number(oldShuttle.Knots) * 1.15).toFixed(2))
 
             shuttles.push(newShuttle)
         }
 
 
     }
-
     res.send(shuttles)
 })
 

--- a/src/routes/shuttle.ts
+++ b/src/routes/shuttle.ts
@@ -6,17 +6,13 @@
  * 
  * Request all shuttles
  * GET /shuttles
- * 
- * Request all shuttles and filter by a given cutoffHour. 
- * This will only return shuttles that have been updated
- * within X number of hours. This defaults to 2.
- * GET /shuttles?cutoffHours=X
- * Returns a 400 if the cutoffHours are invalid.
+ *  Parameters:
+ *      updatedWithin: Int - only show shuttles updated within the past X hours. Defaults to 2.
+ *      Returns a 400 if the updatedWithin are invalid.
  * 
  * Request a specific shuttle given a ID
  * GET /shuttles/:id
- * Returns a 404 if the ID is invalid.
- * 
+ *  Returns a 404 if the ID is invalid.
  * 
  */
 
@@ -39,23 +35,22 @@ router
         let shuttles: Shuttle[] = [];
 
         // Return 2 if the functions fails (such as returns NaN) or if the user provides no number
-        const cutoffHours = Number(req.query["cutoffHours"]) || 2
+        const updatedWithinParam = Number(req.query["updatedWithin"]) || 2
         // check to make sure the cutoff hours is valid
         // > 1 and <= 1 week
-        if (cutoffHours < 1 || cutoffHours >= 1 * 24 * 7) {
-            res.status(400).json({ "error": "cutoffHours is not valid." })
+        if (updatedWithinParam < 0 || updatedWithinParam >= 1 * 24 * 7) {
+            res.status(400).json({ "error": "updatedWithin is not valid. Must be between 0 and 168 (1 week) inclusive." })
         }
-        const twoHoursAgo = new Date(Date.now()).getTime() - (1000 * 1 * 60 * 60 * cutoffHours)
+        const updatedWithinValue = new Date(Date.now()).getTime() - (1000 * 1 * 60 * 60 * updatedWithinParam)
 
         for (var oldShuttle of data as _ChamplainShuttle[]) {
             // Check if the shuttle is within our cutoff time.
             // If it is, add it to the array so it can be returned
-            const isWithinCutoffTime = new Date(oldShuttle.Date_Time) > new Date(twoHoursAgo)
+            const isWithinCutoffTime = new Date(oldShuttle.Date_Time) > new Date(updatedWithinValue)
 
             if (isWithinCutoffTime) {
                 // Format it to how we should return our shuttles.
                 let newShuttle: Shuttle = makeNewShuttle(oldShuttle)
-
                 shuttles.push(newShuttle)
             }
 

--- a/src/routes/shuttle.ts
+++ b/src/routes/shuttle.ts
@@ -34,12 +34,13 @@ router
 
         let shuttles: Shuttle[] = [];
 
-        // Return 2 if the functions fails (such as returns NaN) or if the user provides no number
-        const updatedWithinParam = Number(req.query["updatedWithin"]) || 2
+        // If no value is found, set it to 2. If one is found, and it can't be made
+        // into a number, set it to -1.
+        const updatedWithinParam: number = Number(req.query["updatedWithin"] ?? 2) || -1
         // check to make sure the cutoff hours is valid
         // > 1 and <= 1 week
-        if (updatedWithinParam < 0 || updatedWithinParam >= 1 * 24 * 7) {
-            res.status(400).json({ "error": "updatedWithin is not valid. Must be between 0 and 168 (1 week) inclusive." })
+        if (updatedWithinParam < 0 || updatedWithinParam > 1 * 24 * 7) {
+            res.status(400).json({ "error": "updatedWithin is not valid. Must be between 1 and 168 (1 week) inclusive." })
         }
         const updatedWithinValue = new Date(Date.now()).getTime() - (1000 * 1 * 60 * 60 * updatedWithinParam)
 

--- a/src/routes/shuttle.ts
+++ b/src/routes/shuttle.ts
@@ -39,7 +39,7 @@ router
         let shuttles: Shuttle[] = [];
 
         // Return 2 if the functions fails (such as returns NaN) or if the user provides no number
-        const cutoffHours = Number(req.query["cutoffHours"] ?? 2) || 2
+        const cutoffHours = Number(req.query["cutoffHours"]) || 2
         // check to make sure the cutoff hours is valid
         // > 1 and <= 1 week
         if (cutoffHours < 1 || cutoffHours >= 1 * 24 * 7) {

--- a/src/routes/shuttle.ts
+++ b/src/routes/shuttle.ts
@@ -92,11 +92,11 @@ router
 function makeNewShuttle(oldShuttle: _ChamplainShuttle): Shuttle {
     let newShuttle: Shuttle = Object()
     newShuttle.updated = new Date(oldShuttle.Date_Time_ISO)
-    newShuttle.direction = oldShuttle.Direction
-    newShuttle.lat = oldShuttle.Lat
-    newShuttle.lon = oldShuttle.Lon
+    newShuttle.direction = Number(oldShuttle.Direction)
+    newShuttle.lat = Number(oldShuttle.Lat)
+    newShuttle.lon = Number(oldShuttle.Lon)
     newShuttle.id = Number(oldShuttle.UnitID)
-    newShuttle.mph = String((Number(oldShuttle.Knots) * 1.15).toFixed(2))
+    newShuttle.mph = Number((Number(oldShuttle.Knots) * 1.15).toFixed(2))
     return newShuttle
 }
 

--- a/src/types/shuttle.d.ts
+++ b/src/types/shuttle.d.ts
@@ -9,10 +9,10 @@
 export type Shuttle = {
     updated: Date,
     id: number,
-    lat: string
-    lon: string
-    mph: string
-    direction: string
+    lat: number
+    lon: number
+    mph: number
+    direction: number
 }
 
 

--- a/src/types/shuttle.d.ts
+++ b/src/types/shuttle.d.ts
@@ -7,12 +7,12 @@
  * We also change `Knots` to MPH.
  */
 export type Shuttle = {
-    DateTimeISO: Date,
+    DateTime: Date,
     UnitID: number,
     Lat: string
     Lon: string
-    MPH: number
-    Direction: number
+    MPH: string
+    Direction: string
 }
 
 
@@ -24,7 +24,7 @@ export type _ChamplainShuttle = {
     Date_Time: string
     Date_Time_ISO: string
     UnitID: string
-    Unit_Name: string | Object
+    Unit_Name: string | Object // the newer buses have empty objects as the name.
     Unit_Operator: string
     Lat: string
     Lon: string

--- a/src/types/shuttle.d.ts
+++ b/src/types/shuttle.d.ts
@@ -3,16 +3,16 @@
  * The Shuttle object that our API is returning.
  * This one is different from the Champlain one because it cleans up
  * some unused fields and changes some existing ones.
- * Ours does not include the `Unit_Name` or `Unit_Operator`
- * We also change `Knots` to MPH.
+ * Ours does not include the Unit_Name or Unit_Operator
+ * We also change Knots to MPH.
  */
 export type Shuttle = {
-    DateTime: Date,
-    UnitID: number,
-    Lat: string
-    Lon: string
-    MPH: string
-    Direction: string
+    updated: Date,
+    id: number,
+    lat: string
+    lon: string
+    mph: string
+    direction: string
 }
 
 


### PR DESCRIPTION
This PR adds the `/shuttles` endpoint.

It adds the following routes
- `GET /shuttles`: Gets all shuttles. User can specify a `updatedWithin` parameter to only show shuttles that have been updated within the past X hours. I think the 2nd shuttle stops updating its time when it's not running. If for any reason the user wants to see all running ones, they're able to use this parameter.
- `GET /shuttles/:id` Gets a shuttle given an id.

This can be re-visited once we add authentication to add/update shuttles.


**Whoever merges this, please squash and merge.**